### PR TITLE
Maintenance: Release 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <br>
 
+[→ Release Notes](release-notes.md)
+
 ## What's this about?
 
 This project is about **managing a test suite** for a **Python codebase**

--- a/bin/vfxtest
+++ b/bin/vfxtest
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-python -m vfxtest "$@"

--- a/bin/vfxtest.cmd
+++ b/bin/vfxtest.cmd
@@ -1,3 +1,0 @@
-@echo off
-
-python -m vfxtest %*

--- a/release-notes.md
+++ b/release-notes.md
@@ -7,6 +7,8 @@
     - Added **command line argument** handling.
     - Separated tests that require interactive DCC licenses.
     - Cleaned up console output by hiding internal logging.
+    - Made `run_all_tests.py` fully Python 3.x compatible.
+
 <br>
 
 ## `0.2.1` (09-Sep-2022)

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,26 @@
+# `vfxtest` Release Notes
+
+
+## `Next` (Date)
+
+- **Refactored test suite**: _(→ [Issue #3](https://github.com/martin-chatterjee/vfxtest/issues/3))_
+    - Added **command line argument** handling.
+    - Separated tests that require interactive DCC licenses.
+    - Cleaned up console output by hiding internal logging.
+<br>
+
+## `0.2.1` (09-Sep-2022)
+
+- **Improved virtualenv management**:
+    - Added support for `requirements.txt` files per context.
+    - Added support for `PYTHONPATH` entries per context.
+- **Housekeeping**:
+    - Fixed Python 2/3 compatibility issue.
+    - Added missing `six` requirement in `setup.py`.
+
+<br>
+
+## `0.2.0` (22-Jul-2019)
+
+- Prototypical implementation.
+

--- a/release-notes.md
+++ b/release-notes.md
@@ -17,6 +17,7 @@
     - Introduced `use-environment` context setting for DCC contexts, specifying which Python environment they should use.
       > **Warning**\
       > This is a **breaking change** for DCC contexts. `use-environment` **must** be specified for all DCC contexts.
+    - Now uses `console_scripts` mechanism in `setup.py`.
 
 <br>
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,7 +1,7 @@
 # `vfxtest` Release Notes
 
 
-## `Next` (Date)
+## `0.2.2` (02-Dec-2022)
 
 - **Refactored test suite**: _(→ [Issue #3](https://github.com/martin-chatterjee/vfxtest/issues/3))_
     - Added **command line argument** handling.

--- a/release-notes.md
+++ b/release-notes.md
@@ -9,6 +9,15 @@
     - Cleaned up console output by hiding internal logging.
     - Made `run_all_tests.py` fully Python 3.x compatible.
 
+- **Refactored virtualenv management**: _(→ [Issue #2](https://github.com/martin-chatterjee/vfxtest/issues/2))_
+    - Added introspectable version.
+    - Now `pip install`'s specific `vfxtest` version into every virtualenv, to get set of matching dependencies.
+    - Now copies current `vfxtest.py` file to separate `PYTHONPATH` folder in dcc_settings.
+    - Now executes all subprocesses with the `-m vfxtest` args, instead of the absolute path to `vfxtest.py`.
+    - Introduced `use-environment` context setting for DCC contexts, specifying which Python environment they should use.
+      > **Warning**\
+      > This is a **breaking change** for DCC contexts. `use-environment` **must** be specified for all DCC contexts.
+
 <br>
 
 ## `0.2.1` (09-Sep-2022)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as f:
 
 setup(
     name='vfxtest',
-    version='0.2.1',
+    version='0.2.2',
     license='MIT',
 
     author='Martin Chatterjee',

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,6 @@ setup(
     py_modules=[
         'vfxtest',
     ],
-    scripts=[
-        'bin/vfxtest.cmd',
-        'bin/vfxtest',
-    ],
     install_requires=[
         'virtualenv',
         'coverage >= 4.5',
@@ -57,5 +53,9 @@ setup(
 
     python_requires=('>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, '
                      '!=3.5.*, !=3.6.*, <4'),
-
+    entry_points={
+        "console_scripts": [
+            "vfxtest=vfxtest:main",
+        ]
+    },
 )

--- a/tests/dcc_tests_06_runMain_including_dccs.py
+++ b/tests/dcc_tests_06_runMain_including_dccs.py
@@ -1,0 +1,59 @@
+    # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
+# -----------------------------------------------------------------------------
+
+import unittest
+import os
+import sys
+import json
+
+import vfxtest
+mock = vfxtest.mock
+
+from output_trap import OutputTrap
+
+
+# -----------------------------------------------------------------------------
+class RunMainTestCase(unittest.TestCase):
+
+    # -------------------------------------------------------------------------
+    @classmethod
+    def setUpClass(cls):
+        """
+        """
+        cls.init_target = '{}/test_sandbox/init'.format(os.getcwd().replace('\\', '/'))
+        if not os.path.exists(cls.init_target):
+            os.makedirs(cls.init_target)
+
+    # -------------------------------------------------------------------------
+    @classmethod
+    def tearDownClass(cls):
+        """
+        """
+    # -------------------------------------------------------------------------
+    def setUp(self):
+        """
+        """
+        self.cwd = os.getcwd()
+        os.chdir('./test_sandbox')
+    # -------------------------------------------------------------------------
+    def tearDown(self):
+        """
+        """
+        os.chdir(self.cwd)
+
+    # -------------------------------------------------------------------------
+    def test01_runMain_including_DCCs_works_as_expected(self):
+
+        with OutputTrap():
+            proof = vfxtest.runMain(['--cfg','.config-including-dccs'])
+        self.assertEqual(proof['files_run'], 8)
+        self.assertEqual(proof['tests_run'], 24)
+        self.assertEqual(proof['errors'], 0)
+
+
+
+# -----------------------------------------------------------------------------
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/output_trap.py
+++ b/tests/output_trap.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
+# -----------------------------------------------------------------------------
+
+import unittest
+import sys
+import logging
+
+try:  # pragma: no cover_3
+    from cStringIO import StringIO
+except ImportError:  # pragma: no cover_2
+    from io import StringIO
+
+import vfxtest
+mock = vfxtest.mock
+
+
+# Global constant to completely bypass the functionality.
+BYPASS = False
+
+
+# -----------------------------------------------------------------------------
+class OutputTrap():
+    """Context Manager for trapping any output.
+
+    Swallows all vfxtest and unittest logging, as well as STDOUT and STDERR.
+    This way the console output of the test suite will not polluted by the
+    internal output of the called methods.
+
+    Usage:
+
+        print("This gets logged.")
+        vfxtest.logger.info("This gets logged as well.")
+
+        with OutputTrap():
+            print("This does not appear.")
+            vfxtest.logger.info("This does not appear well.")
+
+        print("This gets logged again.")
+        vfxtest.logger.info("Visible again.")
+
+    """
+
+    # -------------------------------------------------------------------------
+    def __init__(self):
+        self.stored_stdout = sys.stdout
+        self.stored_stderr = sys.stderr
+        self.stored_loglevel = vfxtest.logger.level
+        self.stored_writelndecorator = unittest.runner._WritelnDecorator
+        self.mocked_stdout = StringIO()
+        self.mocked_stderr = StringIO()
+
+        self.mocked_writelndecorator = mock.Mock()
+
+    # -------------------------------------------------------------------------
+    def __enter__(self):
+        if BYPASS:  # pragma: no cover
+            return
+        sys.stdout = self.mocked_stdout
+        sys.stderr = self.mocked_stderr
+        vfxtest.initLogging(level=logging.NOTSET)
+        unittest.runner._WritelnDecorator = self.mocked_writelndecorator
+
+    # -------------------------------------------------------------------------
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if BYPASS:  # pragma: no cover
+            return
+        vfxtest.initLogging(level=self.stored_loglevel)
+        sys.stdout = self.stored_stdout
+        sys.stderr = self.stored_stderr
+        unittest.runner._WritelnDecorator = self.stored_writelndecorator

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -7,29 +7,30 @@
 import os
 import sys
 import platform
-import glob
 import unittest
 import shutil
+import argparse
 
 import coverage
 
+
 # -----------------------------------------------------------------------------
-def main(folder_path, failfast, print_to_stdout, include_test_files):
-    """
-    """
-    test_sandbox = os.path.abspath('./test_sandbox')
-    python = os.path.abspath('..')
+def main(folder_path, test_dccs, fail_fast, log_output, cover_testfiles):
+    """"""
+    test_sandbox = os.path.abspath(os.path.join(folder_path, 'test_sandbox'))
+    python = os.path.abspath(os.path.join(folder_path, '..'))
     sys.path.append(test_sandbox)
     sys.path.append(python)
     os.environ['PYTHONPATH'] = os.pathsep.join([test_sandbox, python])
 
-    # cleanup
-    if os.path.exists('./.output'):
-        shutil.rmtree('./.output')
-
+    # Cleanup.
+    dot_output = os.path.abspath(os.path.join(folder_path, '.output'))
+    if os.path.exists(dot_output):
+        shutil.rmtree(dot_output)
     omit = []
-    if include_test_files is False:
+    if not cover_testfiles:
         omit.append('test*.py')
+        omit.append('dcc_test*.py')
     # add support for Python major version 'no-cover' support:
     # --> no coverage on python 2.x:
     #                                # pragma: no cover_2
@@ -37,8 +38,9 @@ def main(folder_path, failfast, print_to_stdout, include_test_files):
     #                                # pragma: no cover_3
     cov = coverage.Coverage(omit=omit)
     major = platform.python_version_tuple()[0]
-    versioned_exclude = (r'#\s*(pragma|PRAGMA)[:\s]?\s*'
-                         r'(no|NO)\s*(cover_{}|COVER_{})').format(major, major)
+    versioned_exclude = (
+        r'#\s*(pragma|PRAGMA)[:\s]?\s*' r'(no|NO)\s*(cover_{}|COVER_{})'
+    ).format(major, major)
     cov.exclude(versioned_exclude, which='exclude')
     cov.start()
 
@@ -57,15 +59,63 @@ def main(folder_path, failfast, print_to_stdout, include_test_files):
     cov.html_report(directory='_html_coverage')
 
 
+# -----------------------------------------------------------------------------
+def constructParser():
+    """Return argument parser."""
+    parser = argparse.ArgumentParser(
+        prog='run_all_tests',
+        description=('Run test suite for vfxtest.'),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        '-dccs',
+        '--test-dccs',
+        help='Also test dcc related code. '
+        '(Needs a valid Maya and Houdini license, '
+        'and an interactive graphical environment.)',
+        action='store_true',
+    )
+
+    parser.add_argument(
+        '-lo',
+        '--log-output',
+        help='Log all internal output to console.',
+        action='store_true',
+    )
+
+    parser.add_argument(
+        '-ff',
+        '--fail-fast',
+        help='Stop test suite on first error.',
+        action='store_false',
+    )
+
+    parser.add_argument(
+        '-ctf',
+        '--cover-testfiles',
+        help='Include Coverage of test files.',
+        action='store_true',
+    )
+
+    return parser
+
+
+# -----------------------------------------------------------------------------
+def commandLine(arguments):
+    """Handle Command line argument parsing."""
+    parser = constructParser()
+    namespace = parser.parse_args(arguments)
+
+    main(
+        folder_path='.',
+        test_dccs=namespace.test_dccs,
+        fail_fast=namespace.fail_fast,
+        log_output=namespace.log_output,
+        cover_testfiles=namespace.cover_testfiles,
+    )
+
 
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':
-    # pass in any argument to enable 'print to stdout'
-    print_to_stdout = False
-    if len(sys.argv) > 1:
-        print_to_stdout = True
-
-    main(folder_path='.',
-         failfast=True,
-         print_to_stdout=print_to_stdout,
-         include_test_files=False)
+    commandLine(sys.argv[1:])

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -93,10 +93,10 @@ def constructParser():
     )
 
     parser.add_argument(
-        '-ff',
-        '--fail-fast',
-        help='Stop test suite on first error.',
-        action='store_false',
+        '-coe',
+        '--continue-on-error',
+        help='Continue test suite on error.',
+        action='store_true',
     )
 
     parser.add_argument(
@@ -118,7 +118,7 @@ def commandLine(arguments):
     main(
         folder_path='.',
         test_dccs=namespace.test_dccs,
-        fail_fast=namespace.fail_fast,
+        fail_fast=(not namespace.continue_on_error),
         log_output=namespace.log_output,
         cover_testfiles=namespace.cover_testfiles,
     )

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -44,12 +44,14 @@ def main(folder_path, test_dccs, fail_fast, log_output, cover_testfiles):
     cov.exclude(versioned_exclude, which='exclude')
     cov.start()
 
-    # discover all tests and run them
-    loader = unittest.TestLoader()
-    suite = loader.discover(folder_path)
+    # Disable all OutputTraps, if necessary.
+    if log_output:
+        import output_trap
+        output_trap.BYPASS = log_output
 
-    runner = unittest.TextTestRunner(failfast=failfast,
-                                     buffer=(not print_to_stdout))
+    # Prepare and configure.
+    loader = unittest.TestLoader()
+    runner = unittest.TextTestRunner(failfast=fail_fast, buffer=(not log_output))
 
     result = runner.run(suite)
 

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -53,8 +53,14 @@ def main(folder_path, test_dccs, fail_fast, log_output, cover_testfiles):
     loader = unittest.TestLoader()
     runner = unittest.TextTestRunner(failfast=fail_fast, buffer=(not log_output))
 
-    result = runner.run(suite)
+    # Discover and run main test suite.
+    suite = loader.discover(folder_path, pattern='test*.py')
+    runner.run(suite)
 
+    # Discover and tests requiring DCC licenses.
+    if test_dccs is True:
+        dcc_suite = loader.discover(folder_path, pattern='dcc_test*.py')
+        runner.run(dcc_suite)
     cov.stop()
     cov.save()
     cov.report()

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, Martin Chatterjee. All rights reserved.
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
 # -----------------------------------------------------------------------------
 
 import os

--- a/tests/test_sandbox/.config
+++ b/tests/test_sandbox/.config
@@ -32,32 +32,6 @@
                 "python3.x",
                 "python2.x"
             ]
-        },
-
-
-        # ----------------------------
-        "mayapy" :
-        {
-            "executable" : "C:/Program Files/Autodesk/Maya2018/bin/mayapy.exe",
-            "version" : "2018"
-        },
-        # ----------------------------
-        "maya" :
-        {
-            "executable" : "C:/Program Files/Autodesk/Maya2018/bin/maya.exe",
-            "version" : "2018"
-        },
-        # ----------------------------
-        "hython" :
-        {
-            "executable" : "C:/Program Files/Side Effects Software/Houdini 17.5.327/bin/hython.exe",
-            "version" : "17.5.327"
-        },
-        # ----------------------------
-        "houdini" :
-        {
-            "executable" : "C:/Program Files/Side Effects Software/Houdini 17.5.327/bin/houdini.exe",
-            "version" : "17.5.327"
         }
     }
 }

--- a/tests/test_sandbox/.config-including-dccs
+++ b/tests/test_sandbox/.config-including-dccs
@@ -1,0 +1,64 @@
+# -----------------------------------------------------------------------------
+# vfxtest config file, including DCC tests.
+#
+# → Please adjust DCC paths and versions, if necessary.
+# -----------------------------------------------------------------------------
+# (This is essentially just a json file that supports comments)
+
+{
+    "output_folder" : "../.output",
+
+    "debug_mode" : false,
+    "PYTHONPATH" : "./custom_pythonpath",
+
+    # --------------------------------
+    "context_details" :
+    {
+        # ----------------------------
+        "python2.x" :
+        {
+            "executable" : "c:/python27/python.exe",
+            "PYTHONPATH" : "./custom_pythonpath",
+            "requirements" : "./test_requirements.txt"
+        },
+        # ----------------------------
+        "python3.x" :
+        {
+            "executable" : "c:/python37/python.exe"
+        },
+        # ----------------------------
+        "python" :
+        {
+            "nested_contexts" :
+            [
+                "python3.x",
+                "python2.x"
+            ]
+        }
+        ,
+        # ----------------------------
+        "mayapy" :
+        {
+            "executable" : "C:/Program Files/Autodesk/Maya2022/bin/mayapy.exe",
+            "version" : "2022"
+        },
+        # ----------------------------
+        "maya" :
+        {
+            "executable" : "C:/Program Files/Autodesk/Maya2022/bin/maya.exe",
+            "version" : "2022"
+        },
+        # ----------------------------
+        "hython" :
+        {
+            "executable" : "C:/Program Files/Side Effects Software/Houdini 19.0.622/bin/hython.exe",
+            "version" : "19.0.622"
+        },
+        # ----------------------------
+        "houdini" :
+        {
+            "executable" : "C:/Program Files/Side Effects Software/Houdini 19.0.622/bin/houdini.exe",
+            "version" : "19.0.622"
+        }
+    }
+}

--- a/tests/test_sandbox/.config-including-dccs
+++ b/tests/test_sandbox/.config-including-dccs
@@ -40,25 +40,29 @@
         "mayapy" :
         {
             "executable" : "C:/Program Files/Autodesk/Maya2022/bin/mayapy.exe",
-            "version" : "2022"
+            "version" : "2022",
+            "use-environment" : "python3.x"
         },
         # ----------------------------
         "maya" :
         {
             "executable" : "C:/Program Files/Autodesk/Maya2022/bin/maya.exe",
-            "version" : "2022"
+            "version" : "2022",
+            "use-environment" : "python3.x"
         },
         # ----------------------------
         "hython" :
         {
             "executable" : "C:/Program Files/Side Effects Software/Houdini 19.0.622/bin/hython.exe",
-            "version" : "19.0.622"
+            "version" : "19.0.622",
+            "use-environment" : "python3.x"
         },
         # ----------------------------
         "houdini" :
         {
             "executable" : "C:/Program Files/Side Effects Software/Houdini 19.0.622/bin/houdini.exe",
-            "version" : "19.0.622"
+            "version" : "19.0.622",
+            "use-environment" : "python3.x"
         }
     }
 }

--- a/tests/test_sandbox/init/.config
+++ b/tests/test_sandbox/init/.config
@@ -6,15 +6,17 @@
 
 {
 
+
+    # -------------------------------------------------------------------------
     # Define all contexts here that should be run.
     #
     # The context name should match with the subfolder name holding the tests.
     # Nested Contexts are supported as well. In the below setup all tests in
     # subfolder "python" would get run both in the "python2.x" and
     # the "python3.x" context.
-    #
-    # - Adapt the "executables" and "versions" to your setup
-    # - Delete or comment out contexts not needed.
+    # -------------------------------------------------------------------------
+
+
     "context_details" :
     {
         # ---------------------------------------------------------------------
@@ -39,28 +41,41 @@
 
 
         # ---------------------------------------------------------------------
+        # Adapt the executable paths and version of all used DCC's.
+        # Comment out or delete unused DCC contexts.
+        #
+        # Important: 'use-environment' needs to point to a python context that
+        #             is compatible with that DCC's python version.
+        # ---------------------------------------------------------------------
+
+
+        # ---------------------------------------------------------------------
         "mayapy" :
         {
-            "executable" : "C:/Program Files/Autodesk/Maya2018/bin/mayapy.exe",
-            "version" : "2018"
+            "executable" : "C:/Program Files/Autodesk/Maya2022/bin/mayapy.exe",
+            "version" : "2022",
+            "use-environment" : "python3.x"
         },
         # ---------------------------------------------------------------------
         "maya" :
         {
-            "executable" : "C:/Program Files/Autodesk/Maya2018/bin/maya.exe",
-            "version" : "2018"
+            "executable" : "C:/Program Files/Autodesk/Maya2022/bin/maya.exe",
+            "version" : "2022",
+            "use-environment" : "python3.x"
         },
         # ---------------------------------------------------------------------
         "hython" :
         {
-            "executable" : "C:/Program Files/Side Effects Software/Houdini 17.5.229/bin/hython.exe",
-            "version" : "17.5.229"
+            "executable" : "C:/Program Files/Side Effects Software/Houdini 19.0.622/bin/hython.exe",
+            "version" : "19.0.622",
+            "use-environment" : "python3.x"
         },
         # ---------------------------------------------------------------------
         "houdini" :
         {
-            "executable" : "C:/Program Files/Side Effects Software/Houdini 17.5.229/bin/houdini.exe",
-            "version" : "17.5.229"
+            "executable" : "C:/Program Files/Side Effects Software/Houdini 19.0.622/bin/houdini.exe",
+            "version" : "19.0.622",
+            "use-environment" : "python3.x"
         }
     }
 }

--- a/tests/tests_01_argument_handling_and_prep.py
+++ b/tests/tests_01_argument_handling_and_prep.py
@@ -223,37 +223,14 @@ class ArgumentHandlingAndPrepTestCase(unittest.TestCase):
 
         settings = vfxtest.collectSettings(['--cfg',
                                             './test_no-python-contexts.cfg'])
-        # Python 2.x
-        if sys.version.startswith('2.'):
-            vfxtest.prepareTestEnvironment(settings)
-            proof = './no_python_contexts/_dcc_settings/PYTHONPATH/mock/mock.py'
-            self.assertTrue(os.path.exists(proof))
-
-        elif sys.version.startswith('3.'):
-            with self.assertRaises(EnvironmentError):
-                vfxtest.prepareTestEnvironment(settings)
-        else:
-            raise EnvironmentError('Python version not tested: {}'.format(sys.version))
+        vfxtest.prepareTestEnvironment(settings)
+        proof = './no_python_contexts/_dcc_settings/PYTHONPATH/vfxtest.py'
+        self.assertTrue(os.path.exists(proof))
 
         shutil.rmtree('./no_python_contexts')
 
     # -------------------------------------------------------------------------
-    def test15_copyModulesToFolder_works_as_expected(self):
-        if os.path.exists('./copy_modules'):
-            shutil.rmtree('./copy_modules')
-
-        os.makedirs('./copy_modules')
-        module_names = ['os', 'sqlite3',]
-
-        vfxtest._copyModulesToFolder(module_names, './copy_modules')
-
-        self.assertTrue(os.path.exists('./copy_modules/os.py'))
-        self.assertTrue(os.path.exists('./copy_modules/sqlite3/__init__.py'))
-
-        shutil.rmtree('./copy_modules')
-
-    # -------------------------------------------------------------------------
-    def test16_initLogging(self):
+    def test15_initLogging(self):
 
         logger = logging.getLogger('vfxtest')
         vfxtest.initLogging(level=logging.DEBUG, format='PROOF: %(message)s')

--- a/tests/tests_01_argument_handling_and_prep.py
+++ b/tests/tests_01_argument_handling_and_prep.py
@@ -17,6 +17,8 @@ import unittest
 
 import vfxtest
 
+from output_trap import OutputTrap
+
 
 # -----------------------------------------------------------------------------
 class ArgumentHandlingAndPrepTestCase(unittest.TestCase):
@@ -47,14 +49,16 @@ class ArgumentHandlingAndPrepTestCase(unittest.TestCase):
     # -------------------------------------------------------------------------
     def test01_collectSettings_help_raises_SystemError(self):
 
-        with self.assertRaises(SystemExit):
-            result = vfxtest.collectSettings(['--help'])
+        with OutputTrap():
+            with self.assertRaises(SystemExit):
+                result = vfxtest.collectSettings(['--help'])
 
     # -------------------------------------------------------------------------
     def test02_collectSettings_unknown_argument_raises_SystemError(self):
 
-        with self.assertRaises(SystemExit):
-            result = vfxtest.collectSettings(['--doesnotexist'])
+        with OutputTrap():
+            with self.assertRaises(SystemExit):
+                result = vfxtest.collectSettings(['--doesnotexist'])
 
     # -------------------------------------------------------------------------
     def test03_collectSettings_returns_default_args(self):
@@ -110,8 +114,9 @@ class ArgumentHandlingAndPrepTestCase(unittest.TestCase):
             result = vfxtest.collectSettings(['--failfast', item])
             self.assertEqual(result['failfast'], False)
 
-        with self.assertRaises(SystemExit):
-            result = vfxtest.collectSettings(['--failfast', 'Nope'])
+        with OutputTrap():
+            with self.assertRaises(SystemExit):
+                result = vfxtest.collectSettings(['--failfast', 'Nope'])
 
     # -------------------------------------------------------------------------
     def test06_collectSettings_nonexistent_cfg_file_raises_SystemExit(self):
@@ -252,10 +257,9 @@ class ArgumentHandlingAndPrepTestCase(unittest.TestCase):
 
         logger = logging.getLogger('vfxtest')
         vfxtest.initLogging(level=logging.DEBUG, format='PROOF: %(message)s')
-        logger.debug('Proof')
+        self.assertEqual(vfxtest.logger.level, logging.DEBUG)
         vfxtest.initLogging()
-        logger.debug('Not anymore...')
-        logger.info('Back to defaults')
+        self.assertEqual(vfxtest.logger.level, logging.INFO)
 
 
 

--- a/tests/tests_01_argument_handling_and_prep.py
+++ b/tests/tests_01_argument_handling_and_prep.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, Martin Chatterjee. All rights reserved.
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
 # -----------------------------------------------------------------------------
 
 import json

--- a/tests/tests_02_TestCase.py
+++ b/tests/tests_02_TestCase.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, Martin Chatterjee. All rights reserved.
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
 # -----------------------------------------------------------------------------
 
 import unittest

--- a/tests/tests_03_runNative.py
+++ b/tests/tests_03_runNative.py
@@ -10,6 +10,10 @@ import shutil
 import vfxtest
 
 from vfxtest import mock
+
+from output_trap import OutputTrap
+
+
 # -----------------------------------------------------------------------------
 class RunNativeTestCase(unittest.TestCase):
 
@@ -46,7 +50,9 @@ class RunNativeTestCase(unittest.TestCase):
         cov_file = os.path.abspath('{}/.coverage.native'.format(settings['output_folder']))
         if os.path.exists(cov_file):
             os.remove(cov_file)
-        vfxtest.runNative(settings=settings, use_coverage=True)
+
+        with OutputTrap():
+            vfxtest.runNative(settings=settings, use_coverage=True)
 
         self.assertEqual(settings['files_run'], 2)
         self.assertEqual(settings['tests_run'], 6)
@@ -59,7 +65,9 @@ class RunNativeTestCase(unittest.TestCase):
         settings = vfxtest.collectSettings(['--target', '.', '_01',])
         vfxtest.prepareTestEnvironment(settings)
 
-        vfxtest.runNative(settings=settings, use_coverage=False)
+        with OutputTrap():
+            vfxtest.runNative(settings=settings, use_coverage=False)
+
         self.assertEqual(settings['files_run'], 1)
         self.assertEqual(settings['tests_run'], 3)
         self.assertEqual(settings['errors'], 0)
@@ -71,13 +79,17 @@ class RunNativeTestCase(unittest.TestCase):
         vfxtest.prepareTestEnvironment(settings)
 
         settings['context'] = 'differentContext'
-        vfxtest.runNative(settings=settings)
+
+        with OutputTrap():
+            vfxtest.runNative(settings=settings)
+
         self.assertEqual(settings['files_run'], 1)
         self.assertEqual(settings['tests_run'], 3)
         self.assertTrue(os.path.exists('{}/.coverage.differentContext'.format(settings['output_folder'])))
 
-        settings = vfxtest.collectSettings()
-        vfxtest.combineCoverages(settings)
+        with OutputTrap():
+            settings = vfxtest.collectSettings()
+            vfxtest.combineCoverages(settings)
 
         self.assertFalse(os.path.exists('{}/.coverage.differentContext'.format(settings['output_folder'])))
         self.assertTrue(os.path.exists('{}/.coverage'.format(settings['output_folder'])))
@@ -104,7 +116,8 @@ class RunNativeTestCase(unittest.TestCase):
         settings = vfxtest.collectSettings(['--globallimit', '1'])
         vfxtest.prepareTestEnvironment(settings)
 
-        vfxtest.runNative(settings=settings, use_coverage=False)
+        with OutputTrap():
+            vfxtest.runNative(settings=settings, use_coverage=False)
 
         self.assertEqual(settings['files_run'], 1)
         self.assertEqual(settings['tests_run'], 3)
@@ -116,7 +129,8 @@ class RunNativeTestCase(unittest.TestCase):
         settings = vfxtest.collectSettings(['--limit', '1'])
         vfxtest.prepareTestEnvironment(settings)
 
-        vfxtest.runNative(settings=settings, use_coverage=False)
+        with OutputTrap():
+            vfxtest.runNative(settings=settings, use_coverage=False)
 
         self.assertEqual(settings['files_run'], 1)
         self.assertEqual(settings['tests_run'], 3)
@@ -128,7 +142,8 @@ class RunNativeTestCase(unittest.TestCase):
         settings = vfxtest.collectSettings(['--target', './python'])
         vfxtest.prepareTestEnvironment(settings)
 
-        vfxtest.runNative(settings=settings)
+        with OutputTrap():
+            vfxtest.runNative(settings=settings)
 
         self.assertEqual(settings['files_run'], 1)
         self.assertEqual(settings['tests_run'], 3)
@@ -141,7 +156,8 @@ class RunNativeTestCase(unittest.TestCase):
         settings['filter_tokens'].append('does-not-get-matched')
         vfxtest.prepareTestEnvironment(settings)
 
-        vfxtest.runNative(settings=settings)
+        with OutputTrap():
+            vfxtest.runNative(settings=settings)
 
         self.assertEqual(settings['files_run'], 0)
         self.assertEqual(settings['tests_run'], 0)
@@ -151,12 +167,11 @@ class RunNativeTestCase(unittest.TestCase):
     def test10_runNative_with_failfast_stops_on_first_error(self):
 
         settings = vfxtest.collectSettings(['--failfast', 'true'])
-        print(settings['failfast'])
-        print(settings['target'])
 
         vfxtest.prepareTestEnvironment(settings)
-        with mock.patch('awesome_module.buzz', side_effect=Exception()):
-            vfxtest.runNative(settings=settings, use_coverage=False)
+        with OutputTrap():
+            with mock.patch('awesome_module.buzz', return_value=1):
+                vfxtest.runNative(settings=settings, use_coverage=False)
 
         self.assertEqual(settings['files_run'], 1)
         self.assertEqual(settings['tests_run'], 2)

--- a/tests/tests_03_runNative.py
+++ b/tests/tests_03_runNative.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, Martin Chatterjee. All rights reserved.
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
 # -----------------------------------------------------------------------------
 
 import unittest

--- a/tests/tests_04_runTestSuite.py
+++ b/tests/tests_04_runTestSuite.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, Martin Chatterjee. All rights reserved.
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
 # -----------------------------------------------------------------------------
 
 import unittest

--- a/tests/tests_04_runTestSuite.py
+++ b/tests/tests_04_runTestSuite.py
@@ -10,6 +10,8 @@ import json
 import vfxtest
 mock = vfxtest.mock
 
+from output_trap import OutputTrap
+
 
 # -----------------------------------------------------------------------------
 class RunTestSuiteTestCase(unittest.TestCase):
@@ -43,7 +45,8 @@ class RunTestSuiteTestCase(unittest.TestCase):
         settings = vfxtest.collectSettings()
         vfxtest.prepareTestEnvironment(settings)
 
-        vfxtest.runTestSuite(settings=settings)
+        with OutputTrap():
+            vfxtest.runTestSuite(settings=settings)
 
         self.assertEqual(settings['files_run'], 2)
         self.assertEqual(settings['tests_run'], 6)
@@ -62,7 +65,9 @@ class RunTestSuiteTestCase(unittest.TestCase):
         settings['context'] = 'python3.x'
         settings['debug_mode'] = True
 
-        vfxtest.runTestSuite(settings=settings)
+        with OutputTrap():
+            vfxtest.runTestSuite(settings=settings)
+
         self.assertEqual(settings['files_run'], 2)
         self.assertEqual(settings['tests_run'], 6)
         self.assertEqual(settings['errors'], 0)
@@ -83,7 +88,8 @@ class RunTestSuiteTestCase(unittest.TestCase):
 
         settings['context'] = 'python'
 
-        vfxtest.runTestSuite(settings=settings)
+        with OutputTrap():
+            vfxtest.runTestSuite(settings=settings)
 
         self.assertEqual(settings['files_run'], 4)
         self.assertEqual(settings['tests_run'], 12)
@@ -91,16 +97,16 @@ class RunTestSuiteTestCase(unittest.TestCase):
         self.assertTrue(os.path.exists(cov_file_3))
         self.assertTrue(os.path.exists(cov_file_2))
 
-    # # -------------------------------------------------------------------------
-    # def test04_runTestSuite_wrapper_script_not_found_raises_OSError(self):
+    # -------------------------------------------------------------------------
+    def test04_runTestSuite_wrapper_script_not_found_raises_KeyError(self):
 
-    #     settings = vfxtest.collectSettings()
-    #     vfxtest.prepareTestEnvironment(settings)
+        settings = vfxtest.collectSettings()
+        vfxtest.prepareTestEnvironment(settings)
 
-    #     settings['context'] = 'context_without_wrapper_script'
+        settings['context'] = 'context_without_wrapper_script'
 
-    #     with self.assertRaises(OSError):
-    #         vfxtest.runTestSuite(settings=settings)
+        with self.assertRaises(KeyError):
+            vfxtest.runTestSuite(settings=settings)
 
 
     # -------------------------------------------------------------------------
@@ -113,8 +119,9 @@ class RunTestSuiteTestCase(unittest.TestCase):
         settings['debug_mode'] = True
 
         with self.assertRaises(SystemExit):
-            with mock.patch('subprocess.Popen.wait', return_value=13):
-                vfxtest.runTestSuite(settings=settings)
+            with OutputTrap():
+                with mock.patch('subprocess.Popen.wait', return_value=13):
+                    vfxtest.runTestSuite(settings=settings)
 
 # -----------------------------------------------------------------------------
 if __name__ == '__main__':

--- a/tests/tests_05_runMain.py
+++ b/tests/tests_05_runMain.py
@@ -11,6 +11,9 @@ import json
 import vfxtest
 mock = vfxtest.mock
 
+from output_trap import OutputTrap
+
+
 # -----------------------------------------------------------------------------
 class RunMainTestCase(unittest.TestCase):
 
@@ -44,7 +47,8 @@ class RunMainTestCase(unittest.TestCase):
     # -------------------------------------------------------------------------
     def test01_runMain_filtered_works_as_expected(self):
 
-        proof = vfxtest.runMain(['01', '03'])
+        with OutputTrap():
+            proof = vfxtest.runMain(['01', '03'])
 
         self.assertEqual(proof['files_run'], 3)
         self.assertEqual(proof['tests_run'], 9)
@@ -53,7 +57,8 @@ class RunMainTestCase(unittest.TestCase):
     # -------------------------------------------------------------------------
     def test02_runMain_globallimit_works_as_expected(self):
 
-        proof = vfxtest.runMain(['--globallimit', '2'])
+        with OutputTrap():
+            proof = vfxtest.runMain(['--globallimit', '2'])
         self.assertEqual(proof['files_run'], 2)
         self.assertEqual(proof['tests_run'], 6)
         self.assertEqual(proof['errors'], 0)
@@ -61,7 +66,8 @@ class RunMainTestCase(unittest.TestCase):
     # -------------------------------------------------------------------------
     def test03_runMain_with_empty_filtered_result_works_as_expected(self):
 
-        proof = vfxtest.runMain(['asdfg',])
+        with OutputTrap():
+            proof = vfxtest.runMain(['asdfg',])
         self.assertEqual(proof['files_run'], 0)
         self.assertEqual(proof['tests_run'], 0)
         self.assertEqual(proof['errors'], 0)
@@ -69,9 +75,10 @@ class RunMainTestCase(unittest.TestCase):
     # -------------------------------------------------------------------------
     def test04_runMain_works_as_expected(self):
 
-        proof = vfxtest.runMain()
-        self.assertEqual(proof['files_run'], 7)
-        self.assertEqual(proof['tests_run'], 21)
+        with OutputTrap():
+            proof = vfxtest.runMain()
+        self.assertEqual(proof['files_run'], 4)  # 7
+        self.assertEqual(proof['tests_run'], 12) # 21
         self.assertEqual(proof['errors'], 0)
 
     # -------------------------------------------------------------------------

--- a/tests/tests_05_runMain.py
+++ b/tests/tests_05_runMain.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
+    # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019, Martin Chatterjee. All rights reserved.
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
 # -----------------------------------------------------------------------------
 
 import unittest

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -48,6 +48,8 @@ except ImportError: # pragma: no cover_3
 
 import coverage
 
+__version__ = '0.2.1'
+
 main = unittest.main
 
 logger = logging.getLogger('vfxtest')

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019-2021, Martin Chatterjee. All rights reserved.
+# Copyright (c) 2019-2022, Martin Chatterjee. All rights reserved.
 # Licensed under MIT License (--> LICENSE.txt)
 # -----------------------------------------------------------------------------
 

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -1312,16 +1312,6 @@ def _ensureVirtualEnvs(settings):
 
 
 # -----------------------------------------------------------------------------
-def _getPythonVersion(executable):
-    """
-    """
-    proc = subprocess.Popen([executable, '--version'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    proc.wait()
-    out = proc.communicate()[0]
-    version = out.decode('utf-8').replace('Python', '').split()[0]
-    return version
-
-# -----------------------------------------------------------------------------
 def _collectPythonExecutableDetails(settings):
     """Extracts details of all python executables specified in
     context_details.

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -48,7 +48,7 @@ except ImportError: # pragma: no cover_3
 
 import coverage
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 main = unittest.main
 

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -824,8 +824,7 @@ def _getPathToMyself():
     """
     # for Python 2 and 3 compatibility we need to ensure a .py suffix
     my_path = os.path.abspath(__file__).replace('\\', '/')
-    if my_path.endswith('.pyc'):
-        my_path = my_path.replace('.pyc', '.py')
+    my_path = my_path.replace('.pyc', '.py')
     return my_path
 
 

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -744,8 +744,7 @@ def _preparePatchedEnvironment(settings, executable, context):
         if os.path.basename(exe_folder).lower() == expected_name:
             venv_root = os.path.dirname(exe_folder)
             env['VIRTUAL_ENV'] = str(venv_root)
-            if 'PYTHONHOME' in env:
-                env.pop('PYTHONHOME')
+            env.pop('PYTHONHOME', None)
             env['PATH'] = '{}{}{}'.format(exe_folder, os.pathsep, env['PATH'])
 
 

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -1414,9 +1414,9 @@ def _initializeVirtualEnv(venv_path, details, dcc_settings_path):
             sys.stdout.write(line)
         proc.wait()
 
-    # Remove vfxtest.py file from virtualenv.
+    # Remove 'vfxtest.py' file from virtualenv, if it exists.
     vfxtest_py = os.path.join(venv_path, 'Lib', 'site-packages', 'vfxtest.py')
-    if os.path.exists(vfxtest_py):
+    if os.path.exists(vfxtest_py): # pragma: no cover
         os.remove(vfxtest_py)
 
     logger.info('/'*80)

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -322,7 +322,7 @@ def runInSubprocess(settings, context):
                env=env) as proc:
         sys.stdout.flush()
         while True:
-            line = proc.stdout.readline()
+            line = proc.stdout.readline().decode()
             if not line:
                 break
             if not _updateStatsFromStdout(settings, line):

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -1849,6 +1849,9 @@ class TestCase(unittest.TestCase):
 
 
 # -----------------------------------------------------------------------------
-if __name__ == '__main__':
-    runMain(sys.argv[1:]) # pragma: no cover
+def main(): # pragma: no cover
+    runMain(sys.argv[1:])
 
+# -----------------------------------------------------------------------------
+if __name__ == '__main__':
+    main() # pragma: no cover

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -735,6 +735,16 @@ def _preparePatchedEnvironment(settings, executable, context):
     if 'PYTHONPATH' in settings['context_details'][context]:
         context_pypath = str(settings['context_details'][context]['PYTHONPATH'])
         pypath_tokens.append(os.path.abspath(context_pypath))
+    # Deal with optional 'use-environment' setting.
+    use_env_name = settings['context_details'][context].get('use-environment', None)
+    if use_env_name:
+        virtualenv_site_packages = os.path.join(
+            settings['dcc_settings_path'],
+            'virtualenv_{}'.format(use_env_name),
+            'Lib',
+            'site-packages',
+        )
+        pypath_tokens.append(virtualenv_site_packages)
 
     pypath_tokens = [token for token in pypath_tokens if len(token)]
     env['PYTHONPATH'] = os.pathsep.join(pypath_tokens)

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -271,11 +271,11 @@ def runInSubprocess(settings, context):
 
     executable = _getExecutable(ctxt_settings)
     env = _preparePatchedEnvironment(ctxt_settings, executable, context)
-    vfxtest_py = _getPathToMyself()
     args = [executable, ]
     is_maya = False
     if context.lower().find('mayapy') != -1:
-        args.append(vfxtest_py)
+        args.append('-m')
+        args.append('vfxtest')
 
     elif context.lower().find('maya') != -1:
         is_maya = True
@@ -283,7 +283,8 @@ def runInSubprocess(settings, context):
         args.append('source vfxtest_maya; vfxtestSchedule();')
 
     elif context.lower().find('hython') != -1:
-        args.append(vfxtest_py)
+        args.append('-m')
+        args.append('vfxtest')
 
     elif context.lower().find('houdini') != -1:
         dcc_settings = settings['dcc_settings_path']
@@ -291,7 +292,8 @@ def runInSubprocess(settings, context):
         args.append(hou_helper)
 
     else:
-        args.append(vfxtest_py)
+        args.append('-m')
+        args.append('vfxtest')
 
     logger.info('')
     logger.info('/'*80)

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -1439,15 +1439,17 @@ def _getSampleConfigContent():
 
 {
 
+
+    # -------------------------------------------------------------------------
     # Define all contexts here that should be run.
     #
     # The context name should match with the subfolder name holding the tests.
     # Nested Contexts are supported as well. In the below setup all tests in
     # subfolder "python" would get run both in the "python2.x" and
     # the "python3.x" context.
-    #
-    # - Adapt the "executables" and "versions" to your setup
-    # - Delete or comment out contexts not needed.
+    # -------------------------------------------------------------------------
+
+
     "context_details" :
     {
         # ---------------------------------------------------------------------
@@ -1472,28 +1474,41 @@ def _getSampleConfigContent():
 
 
         # ---------------------------------------------------------------------
+        # Adapt the executable paths and version of all used DCC's.
+        # Comment out or delete unused DCC contexts.
+        #
+        # Important: 'use-environment' needs to point to a python context that
+        #             is compatible with that DCC's python version.
+        # ---------------------------------------------------------------------
+
+
+        # ---------------------------------------------------------------------
         "mayapy" :
         {
-            "executable" : "C:/Program Files/Autodesk/Maya2018/bin/mayapy.exe",
-            "version" : "2018"
+            "executable" : "C:/Program Files/Autodesk/Maya2022/bin/mayapy.exe",
+            "version" : "2022",
+            "use-environment" : "python3.x"
         },
         # ---------------------------------------------------------------------
         "maya" :
         {
-            "executable" : "C:/Program Files/Autodesk/Maya2018/bin/maya.exe",
-            "version" : "2018"
+            "executable" : "C:/Program Files/Autodesk/Maya2022/bin/maya.exe",
+            "version" : "2022",
+            "use-environment" : "python3.x"
         },
         # ---------------------------------------------------------------------
         "hython" :
         {
-            "executable" : "C:/Program Files/Side Effects Software/Houdini 17.5.229/bin/hython.exe",
-            "version" : "17.5.229"
+            "executable" : "C:/Program Files/Side Effects Software/Houdini 19.0.622/bin/hython.exe",
+            "version" : "19.0.622",
+            "use-environment" : "python3.x"
         },
         # ---------------------------------------------------------------------
         "houdini" :
         {
-            "executable" : "C:/Program Files/Side Effects Software/Houdini 17.5.229/bin/houdini.exe",
-            "version" : "17.5.229"
+            "executable" : "C:/Program Files/Side Effects Software/Houdini 19.0.622/bin/houdini.exe",
+            "version" : "19.0.622",
+            "use-environment" : "python3.x"
         }
     }
 }

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -896,7 +896,7 @@ def _startCoverage(settings):
 
 
 # -----------------------------------------------------------------------------
-def _stopCoverage(settings, cov, report=True):
+def _stopCoverage(settings, cov, report=True): # pragma: no cover
     """Stops the code coverage.
 
     Args:
@@ -906,9 +906,8 @@ def _stopCoverage(settings, cov, report=True):
                           (Optional, defaults to True)
 
     """
-    # --> 'cov.stop()' can't be covered:
-    #     coverage does not work inside of another coverage run
-    cov.stop() # pragma: no cover
+    #  → Coverage does not work inside of another coverage run.
+    cov.stop()
 
     if settings['tests_run'] == 0:
         return

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -1231,9 +1231,7 @@ def _ensureRequirements(target_path, name='requirements.txt'):
     file_path = '{}/{}'.format(target_path, name)
 
     with open(file_path, 'w') as f:
-        f.write('coverage >= 4.5\n')
-        f.write('mock >= 3.0; python_version < "3.3"\n')
-        f.write('six\n')
+        f.write('vfxtest=={}\n'.format(__version__))
 
 
 # -----------------------------------------------------------------------------

--- a/vfxtest.py
+++ b/vfxtest.py
@@ -1417,6 +1417,11 @@ def _initializeVirtualEnv(venv_path, details, dcc_settings_path):
             sys.stdout.write(line)
         proc.wait()
 
+    # Remove vfxtest.py file from virtualenv.
+    vfxtest_py = os.path.join(venv_path, 'Lib', 'site-packages', 'vfxtest.py')
+    if os.path.exists(vfxtest_py):
+        os.remove(vfxtest_py)
+
     logger.info('/'*80)
     logger.info('')
 


### PR DESCRIPTION
# Release Notes

## `0.2.2`

- **Refactored test suite**: _(→ [Issue #3](https://github.com/martin-chatterjee/vfxtest/issues/3))_
    - Added **command line argument** handling.
    - Separated tests that require interactive DCC licenses.
    - Cleaned up console output by hiding internal logging.
    - Made `run_all_tests.py` fully Python 3.x compatible.

- **Refactored virtualenv management**: _(→ [Issue #2](https://github.com/martin-chatterjee/vfxtest/issues/2))_
    - Added introspectable version.
    - Now `pip install`'s specific `vfxtest` version into every virtualenv, to get set of matching dependencies.
    - Now copies current `vfxtest.py` file to separate `PYTHONPATH` folder in dcc_settings.
    - Now executes all subprocesses with the `-m vfxtest` args, instead of the absolute path to `vfxtest.py`.
    - Introduced `use-environment` context setting for DCC contexts, specifying which Python environment they should use.
      > **Warning**\
      > This is a **breaking change** for DCC contexts. `use-environment` **must** be specified for all DCC contexts.
    - Now uses `console_scripts` mechanism in `setup.py`.
